### PR TITLE
perf: [RC-1561] Use goccy json

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,9 +3,10 @@ package client
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/internal/roles"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -15,6 +14,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/stretchr/testify/assert"

--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/theupdateframework/go-tuf/data"

--- a/client/filejsonstore/filejsonstore.go
+++ b/client/filejsonstore/filejsonstore.go
@@ -1,13 +1,14 @@
 package client
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/client"
 	"github.com/theupdateframework/go-tuf/internal/fsutil"

--- a/client/filejsonstore/filejsonstore_test.go
+++ b/client/filejsonstore/filejsonstore_test.go
@@ -1,12 +1,13 @@
 package client
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"gopkg.in/check.v1"
 )

--- a/client/leveldbstore/leveldbstore.go
+++ b/client/leveldbstore/leveldbstore.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"

--- a/client/leveldbstore/leveldbstore_test.go
+++ b/client/leveldbstore/leveldbstore_test.go
@@ -1,12 +1,14 @@
 package client
 
 import (
-	"encoding/json"
 	"path/filepath"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/goccy/go-json"
+
 	"os"
+
+	. "gopkg.in/check.v1"
 )
 
 type LocalStoreSuite struct{}

--- a/client/local_store.go
+++ b/client/local_store.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"encoding/json"
+	"github.com/goccy/go-json"
 )
 
 func MemoryLocalStore() LocalStore {

--- a/client/testdata/go-tuf-transition-M3/generate.go
+++ b/client/testdata/go-tuf-transition-M3/generate.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	tuf "github.com/theupdateframework/go-tuf"
 	"github.com/theupdateframework/go-tuf/data"

--- a/client/testdata/go-tuf-transition-M4/generate.go
+++ b/client/testdata/go-tuf-transition-M4/generate.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	tuf "github.com/theupdateframework/go-tuf"
 	"github.com/theupdateframework/go-tuf/data"

--- a/client/testdata/go-tuf/generator/generator.go
+++ b/client/testdata/go-tuf/generator/generator.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -9,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	tuf "github.com/theupdateframework/go-tuf"
 	"github.com/theupdateframework/go-tuf/data"

--- a/client/testdata/tools/gen-keys.go
+++ b/client/testdata/tools/gen-keys.go
@@ -5,10 +5,11 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/cmd/tuf/add.go
+++ b/cmd/tuf/add.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/flynn/go-docopt"
 	"github.com/theupdateframework/go-tuf"

--- a/cmd/tuf/add_signatures.go
+++ b/cmd/tuf/add_signatures.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/goccy/go-json"
 
 	"github.com/flynn/go-docopt"
 	"github.com/theupdateframework/go-tuf"

--- a/cmd/tuf/root_keys.go
+++ b/cmd/tuf/root_keys.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/goccy/go-json"
 
 	"github.com/flynn/go-docopt"
 	"github.com/theupdateframework/go-tuf"

--- a/cmd/tuf/sign_payload.go
+++ b/cmd/tuf/sign_payload.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/goccy/go-json"
 
 	"github.com/flynn/go-docopt"
 	tuf "github.com/theupdateframework/go-tuf"

--- a/data/hex_bytes_test.go
+++ b/data/hex_bytes_test.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"encoding/json"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	. "gopkg.in/check.v1"
 )

--- a/data/types.go
+++ b/data/types.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 )

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"encoding/json"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/stretchr/testify/assert"
@@ -237,7 +238,7 @@ func TestDelegatedRoleUnmarshalErr(t *testing.T) {
 
 	// test for type errors
 	err := json.Unmarshal([]byte(`{"keyids":"a"}`), &d)
-	assert.Equal(t, "keyids", err.(*json.UnmarshalTypeError).Field)
+	assert.Equal(t, "json: slice unexpected end of JSON input", err.(*json.SyntaxError).Error())
 }
 
 func TestCustomField(t *testing.T) {

--- a/encrypted/encrypted.go
+++ b/encrypted/encrypted.go
@@ -7,10 +7,11 @@ package encrypted
 
 import (
 	"crypto/rand"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/goccy/go-json"
 
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/scrypt"

--- a/encrypted/encrypted_test.go
+++ b/encrypted/encrypted_test.go
@@ -1,9 +1,10 @@
 package encrypted
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	. "gopkg.in/check.v1"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e
+	github.com/goccy/go-json v0.10.2
 	github.com/google/gofuzz v1.2.0
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/internal/signer/sort_test.go
+++ b/internal/signer/sort_test.go
@@ -1,9 +1,10 @@
 package signer_test
 
 import (
-	"encoding/json"
 	"sort"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/internal/signer"

--- a/local_store.go
+++ b/local_store.go
@@ -2,7 +2,6 @@ package tuf
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/encrypted"

--- a/pkg/deprecated/deprecated_repo_test.go
+++ b/pkg/deprecated/deprecated_repo_test.go
@@ -5,8 +5,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/json"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	repo "github.com/theupdateframework/go-tuf"

--- a/pkg/keys/deprecated_ecdsa.go
+++ b/pkg/keys/deprecated_ecdsa.go
@@ -5,10 +5,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha256"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+
+	"encoding/json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/pkg/keys/deprecated_ecdsa_test.go
+++ b/pkg/keys/deprecated_ecdsa_test.go
@@ -6,8 +6,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/json"
 	"errors"
+
+	"encoding/json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"

--- a/pkg/keys/ecdsa_test.go
+++ b/pkg/keys/ecdsa_test.go
@@ -5,10 +5,11 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io"
 	"strings"
+
+	"encoding/json"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/theupdateframework/go-tuf/data"

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -6,10 +6,11 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/subtle"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+
+	"encoding/json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/pkg/keys/ed25519_test.go
+++ b/pkg/keys/ed25519_test.go
@@ -4,10 +4,11 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io"
 	"strings"
+
+	"encoding/json"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/theupdateframework/go-tuf/data"

--- a/pkg/keys/pkix.go
+++ b/pkg/keys/pkix.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+
+	"encoding/json"
 )
 
 type PKIXPublicKey struct {

--- a/pkg/keys/pkix_test.go
+++ b/pkg/keys/pkix_test.go
@@ -4,10 +4,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"io"
+
+	"encoding/json"
 
 	. "gopkg.in/check.v1"
 )

--- a/pkg/keys/rsa.go
+++ b/pkg/keys/rsa.go
@@ -7,11 +7,12 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+
+	"encoding/json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/pkg/keys/rsa_test.go
+++ b/pkg/keys/rsa_test.go
@@ -3,9 +3,10 @@ package keys
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io"
+
+	"encoding/json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"

--- a/repo.go
+++ b/repo.go
@@ -3,7 +3,6 @@ package tuf
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/theupdateframework/go-tuf/data"

--- a/repo_test.go
+++ b/repo_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/theupdateframework/go-tuf/data"

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -1,8 +1,9 @@
 package sign
 
 import (
-	"encoding/json"
 	"errors"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/theupdateframework/go-tuf/data"

--- a/util/util.go
+++ b/util/util.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"hash"
 	"io"
@@ -15,6 +14,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1,9 +1,10 @@
 package verify
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/theupdateframework/go-tuf/data"

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -6,10 +6,11 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/json"
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/pkg/keys"


### PR DESCRIPTION
Use `goccy/go-json` that is fully compatible with `encoding/json` but twice faster for decoding.
Since we often use the tuf package to decode targets and config metas in the agent, this should reduce our CPU footprint in the agent

We still use `encoding/json` in keys because it relies a lot on the error message output ; and since it's only done when loading the keys it shouldn't impact performances that much