### PR TITLE
perf(go-tuf): Add LFU cache on verification's deserialization

### DIFF
--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -12,15 +12,19 @@ import (
 
 	"encoding/json"
 
+	"github.com/dgrijalva/lfu-go"
 	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/lfu"
 )
 
-var lfuCache = lfu.New(100, 10)
+var lfuCache *lfu.Cache
 
 func init() {
 	SignerMap.Store(data.KeyTypeEd25519, NewEd25519Signer)
 	VerifierMap.Store(data.KeyTypeEd25519, NewEd25519Verifier)
+
+	lfuCache = lfu.New()
+	lfuCache.UpperBound = 100
+	lfuCache.LowerBound = 10
 }
 
 func NewEd25519Signer() Signer {

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -43,10 +43,8 @@ func (e *ed25519Verifier) Public() string {
 func (e *ed25519Verifier) Verify(msg, sig []byte) error {
 	key := fmt.Sprintf("key:%s,msg:%s,sig:%s", e.PublicKey, msg, sig)
 	var valid bool
-	if rawCached := lfuCache.Get(key); rawCached != nil {
-		if cached, ok := rawCached.(bool); ok {
-			valid = cached
-		}
+	if cached, ok := lfuCache.Get(key).(bool); ok {
+		valid = cached
 	} else {
 		valid = ed25519.Verify([]byte(e.PublicKey), msg, sig)
 		lfuCache.Set(key, valid)

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -23,8 +23,8 @@ func init() {
 	VerifierMap.Store(data.KeyTypeEd25519, NewEd25519Verifier)
 
 	lfuCache = lfu.New()
-	lfuCache.UpperBound = 100
-	lfuCache.LowerBound = 10
+	lfuCache.UpperBound = 200
+	lfuCache.LowerBound = 50
 }
 
 func NewEd25519Signer() Signer {


### PR DESCRIPTION
Based on https://github.com/DataDog/go-tuf/pull/62

**Description of the changes being introduced by the pull request**:
Adds an LFU cache on ed25519 `Verify` deserialization

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
