### PR TITLE
perf(go-tuf): Use goccy where missing

### DIFF
--- a/pkg/keys/deprecated_ecdsa.go
+++ b/pkg/keys/deprecated_ecdsa.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/pkg/keys/deprecated_ecdsa_test.go
+++ b/pkg/keys/deprecated_ecdsa_test.go
@@ -8,7 +8,7 @@ import (
 	"crypto/sha256"
 	"errors"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"

--- a/pkg/keys/ecdsa.go
+++ b/pkg/keys/ecdsa.go
@@ -7,11 +7,12 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/pkg/keys/ecdsa_test.go
+++ b/pkg/keys/ecdsa_test.go
@@ -5,11 +5,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"io"
 	"strings"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/theupdateframework/go-tuf/data"
@@ -124,7 +123,7 @@ func (ECDSASuite) TestUnmarshalECDSA_Invalid(c *C) {
 		Value:      badKeyValue,
 	}
 	verifier := NewEcdsaVerifier()
-	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "json: cannot unmarshal.*")
+	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "invalid character 't' looking for beginning of value")
 }
 
 func (ECDSASuite) TestUnmarshalECDSA_FastFuzz(c *C) {
@@ -160,5 +159,5 @@ func (ECDSASuite) TestUnmarshalECDSA_TooLongContent(c *C) {
 	}
 	verifier := NewEcdsaVerifier()
 	err = verifier.UnmarshalPublicKey(badKey)
-	c.Assert(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
+	c.Assert(err.Error(), Equals, "json: value of string unexpected end of JSON input")
 }

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/dgrijalva/lfu-go"
 	"github.com/theupdateframework/go-tuf/data"

--- a/pkg/keys/ed25519_test.go
+++ b/pkg/keys/ed25519_test.go
@@ -4,11 +4,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"io"
 	"strings"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/theupdateframework/go-tuf/data"
@@ -48,7 +47,7 @@ func (Ed25519Suite) TestUnmarshalEd25519_Invalid(c *C) {
 		Value:      badKeyValue,
 	}
 	verifier := NewEd25519Verifier()
-	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "json: cannot unmarshal.*")
+	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "invalid character 't' looking for beginning of value")
 }
 
 func (Ed25519Suite) TestUnmarshalEd25519_FastFuzz(c *C) {
@@ -84,7 +83,7 @@ func (Ed25519Suite) TestUnmarshalEd25519_TooLongContent(c *C) {
 	}
 	verifier := NewEd25519Verifier()
 	err = verifier.UnmarshalPublicKey(badKey)
-	c.Assert(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
+	c.Assert(err.Error(), Equals, "json: value of string unexpected end of JSON input")
 }
 
 func (Ed25519Suite) TestSignVerify(c *C) {

--- a/pkg/keys/pkix.go
+++ b/pkg/keys/pkix.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 )
 
 type PKIXPublicKey struct {

--- a/pkg/keys/pkix_test.go
+++ b/pkg/keys/pkix_test.go
@@ -5,10 +5,9 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"io"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	. "gopkg.in/check.v1"
 )
@@ -59,5 +58,5 @@ func (PKIXSuite) TestUnmarshalPKIX_TooLongContent(c *C) {
 
 	var k PKIXPublicKey
 	err = json.Unmarshal(tooLongPayload, &k)
-	c.Assert(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
+	c.Assert(err.Error(), Equals, "json: string unexpected end of JSON input")
 }

--- a/pkg/keys/rsa.go
+++ b/pkg/keys/rsa.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"io"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 )

--- a/pkg/keys/rsa_test.go
+++ b/pkg/keys/rsa_test.go
@@ -3,10 +3,9 @@ package keys
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"io"
 
-	"encoding/json"
+	"github.com/goccy/go-json"
 
 	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"
@@ -88,7 +87,7 @@ func (ECDSASuite) TestUnmarshalRSA_Invalid(c *C) {
 		Value:      badKeyValue,
 	}
 	verifier := NewEcdsaVerifier()
-	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "json: cannot unmarshal.*")
+	c.Assert(verifier.UnmarshalPublicKey(badKey), ErrorMatches, "invalid character 't' looking for beginning of value")
 }
 
 func (ECDSASuite) TestUnmarshalRSAPublicKey(c *C) {
@@ -122,5 +121,5 @@ func (ECDSASuite) TestUnmarshalRSA_TooLongContent(c *C) {
 	}
 	verifier := newRsaVerifier()
 	err = verifier.UnmarshalPublicKey(badKey)
-	c.Assert(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
+	c.Assert(err.Error(), Equals, "json: value of string unexpected end of JSON input")
 }


### PR DESCRIPTION
Based on https://github.com/DataDog/go-tuf/pull/63

**Description of the changes being introduced by the pull request**:
Finishes using goccy's json where possible

**Please verify and check that the pull request fulfills the following requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
