### PR TITLE
chore(go-tuf): Replace all imports from theupdateframework to DataDog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-tuf
 
-[![build](https://github.com/theupdateframework/go-tuf/workflows/build/badge.svg)](https://github.com/theupdateframework/go-tuf/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/theupdateframework/go-tuf/badge.svg)](https://coveralls.io/github/theupdateframework/go-tuf) [![PkgGoDev](https://pkg.go.dev/badge/github.com/theupdateframework/go-tuf)](https://pkg.go.dev/github.com/theupdateframework/go-tuf) [![Go Report Card](https://goreportcard.com/badge/github.com/theupdateframework/go-tuf)](https://goreportcard.com/report/github.com/theupdateframework/go-tuf)
+[![build](https://github.com/DataDog/go-tuf/workflows/build/badge.svg)](https://github.com/DataDog/go-tuf/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/theupdateframework/go-tuf/badge.svg)](https://coveralls.io/github/theupdateframework/go-tuf) [![PkgGoDev](https://pkg.go.dev/badge/github.com/DataDog/go-tuf)](https://pkg.go.dev/github.com/DataDog/go-tuf) [![Go Report Card](https://goreportcard.com/badge/github.com/DataDog/go-tuf)](https://goreportcard.com/report/github.com/DataDog/go-tuf)
 
 This is a Go implementation of [The Update Framework (TUF)](http://theupdateframework.com/),
 a framework for securing software update systems.
@@ -35,7 +35,7 @@ The directories contain the following files:
 `go-tuf` is tested on Go versions 1.18.
 
 ```bash
-go install github.com/theupdateframework/go-tuf/cmd/tuf@latest
+go install github.com/DataDog/go-tuf/cmd/tuf@latest
 ```
 
 ### Commands
@@ -154,7 +154,7 @@ If the signature does not verify, it will not be added.
 
 #### `tuf status --valid-at <date> <role>`
 
-Check if the role's metadata will be expired on the given date. 
+Check if the role's metadata will be expired on the given date.
 
 #### Usage of environment variables
 
@@ -638,9 +638,9 @@ $ tuf commit
 
 ## Client
 
-For the client package, see https://godoc.org/github.com/theupdateframework/go-tuf/client.
+For the client package, see https://godoc.org/github.com/DataDog/go-tuf/client.
 
-For the client CLI, see https://github.com/theupdateframework/go-tuf/tree/master/cmd/tuf-client.
+For the client CLI, see https://github.com/DataDog/go-tuf/tree/master/cmd/tuf-client.
 
 ## Contributing and Development
 
@@ -659,4 +659,3 @@ Please see [CONTRIBUTING.md](docs/CONTRIBUTING.md) for contribution guidelines b
 There are TUF implementations in a variety of programming languages. Some other Go implementations of TUF include:
 
 * [Notary](https://github.com/notaryproject/notary): A version of TUF designed specifically for publishing and managing trusted collections of content. It was used by Docker Content Trust, and has since been superseded by the [Notation](https://github.com/notaryproject/notation) project. In contrast, go-tuf is a direct implementation of TUF and has been updated to conform to 1.0.0 of the TUF specification.
-

--- a/client/client.go
+++ b/client/client.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/roles"
-	"github.com/theupdateframework/go-tuf/util"
-	"github.com/theupdateframework/go-tuf/verify"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/roles"
+	"github.com/DataDog/go-tuf/util"
+	"github.com/DataDog/go-tuf/verify"
 )
 
 const (

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -17,15 +17,15 @@ import (
 
 	"github.com/goccy/go-json"
 
+	tuf "github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/sets"
+	"github.com/DataDog/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/sign"
+	"github.com/DataDog/go-tuf/util"
+	"github.com/DataDog/go-tuf/verify"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/stretchr/testify/assert"
-	tuf "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/sets"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
-	"github.com/theupdateframework/go-tuf/sign"
-	"github.com/theupdateframework/go-tuf/util"
-	"github.com/theupdateframework/go-tuf/verify"
 	. "gopkg.in/check.v1"
 )
 
@@ -371,7 +371,7 @@ func (s *ClientSuite) TestInit(c *C) {
 	c.Assert(err, IsNil)
 }
 
-// This is a regression test for https://github.com/theupdateframework/go-tuf/issues/370
+// This is a regression test for https://github.com/DataDog/go-tuf/issues/370
 // where a single invalid signature resulted in an early return.
 // Instead, the client should have continued and counted the number
 // of valid signatures, ignoring the incorrect one.
@@ -481,7 +481,7 @@ func (s *ClientSuite) TestNewRoot(c *C) {
 	}
 }
 
-// This is a regression test for https://github.com/theupdateframework/go-tuf/issues/370
+// This is a regression test for https://github.com/DataDog/go-tuf/issues/370
 // where a single invalid signature resulted in an early return.
 // Instead, the client should have continued and counted the number
 // of valid signatures, ignoring the incorrect one.
@@ -582,7 +582,7 @@ func (s *ClientSuite) TestUpdateRoots(c *C) {
 		{"testdata/Published3Times_keyrotated_latestrootexpired", ErrDecodeFailed{File: "root.json", Err: verify.ErrExpired{}}, map[string]int64{"root": 2, "timestamp": 1, "snapshot": 1, "targets": 1}},
 		// Fails updating root from version 1 to version 2 when old root 1 did not sign off on it (nth root didn't sign off n+1).
 		// TODO(asraa): This testcase should have revoked the old key!
-		// https://github.com/theupdateframework/go-tuf/issues/417
+		// https://github.com/DataDog/go-tuf/issues/417
 		{"testdata/Published2Times_keyrotated_invalidOldRootSignature", nil, map[string]int64{}},
 		// Fails updating root from version 1 to version 2 when the new root 2 did not sign itself (n+1th root didn't sign off n+1)
 		{"testdata/Published2Times_keyrotated_invalidNewRootSignature", verify.ErrRoleThreshold{Expected: 1, Actual: 0}, map[string]int64{}},
@@ -1547,7 +1547,7 @@ func (s *StateLessSuite) TestRejectsMultiSignaturesSameKeyDifferentIDs(c *C) {
 	// This test checks that the TUF client
 	// will not accept a root rotation
 	// signed twice with Alice's key with different key IDs each time.
-	// This test was failing with https://github.com/theupdateframework/go-tuf/tree/ac7b5d7bce18cca5a84a28b021bd6372f450b35b
+	// This test was failing with https://github.com/DataDog/go-tuf/tree/ac7b5d7bce18cca5a84a28b021bd6372f450b35b
 	// because the signature verification code was assuming that the key IDs used in the metadata
 	// were the same as the one the TUF library of the client would generate,
 	// breaking the security of threshold signatures.
@@ -1575,7 +1575,7 @@ func (s *StateLessSuite) TestRejectsMultiSignaturesSameKeyDifferentIDs(c *C) {
 	}
 
 	// reproduces how IDs were computed in
-	// https://github.com/theupdateframework/go-tuf/blob/8e84384bebe3/data/types.go#L50
+	// https://github.com/DataDog/go-tuf/blob/8e84384bebe3/data/types.go#L50
 	oldTUFIDs := func(k *data.PublicKey) []string {
 		bytes, _ := cjson.EncodeCanonical(k)
 		digest := sha256.Sum256(bytes)

--- a/client/delegations.go
+++ b/client/delegations.go
@@ -1,9 +1,9 @@
 package client
 
 import (
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/targets"
-	"github.com/theupdateframework/go-tuf/verify"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/targets"
+	"github.com/DataDog/go-tuf/verify"
 )
 
 // getTargetFileMeta searches for a verified TargetFileMeta matching a target

--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/util"
+	"github.com/DataDog/go-tuf/verify"
 	"github.com/stretchr/testify/assert"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/util"
-	"github.com/theupdateframework/go-tuf/verify"
 )
 
 func TestGetTargetMeta(t *testing.T) {

--- a/client/filejsonstore/filejsonstore.go
+++ b/client/filejsonstore/filejsonstore.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/client"
-	"github.com/theupdateframework/go-tuf/internal/fsutil"
-	"github.com/theupdateframework/go-tuf/util"
+	"github.com/DataDog/go-tuf/client"
+	"github.com/DataDog/go-tuf/internal/fsutil"
+	"github.com/DataDog/go-tuf/util"
 )
 
 const (

--- a/client/interop_test.go
+++ b/client/interop_test.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/theupdateframework/go-tuf/util"
+	"github.com/DataDog/go-tuf/util"
 	. "gopkg.in/check.v1"
 
-	goTufGenerator "github.com/theupdateframework/go-tuf/client/testdata/go-tuf/generator"
+	goTufGenerator "github.com/DataDog/go-tuf/client/testdata/go-tuf/generator"
 )
 
 type InteropSuite struct{}

--- a/client/leveldbstore/leveldbstore.go
+++ b/client/leveldbstore/leveldbstore.go
@@ -7,7 +7,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 
-	tuf_client "github.com/theupdateframework/go-tuf/client"
+	tuf_client "github.com/DataDog/go-tuf/client"
 )
 
 func FileLocalStore(path string) (tuf_client.LocalStore, error) {

--- a/client/python_interop/python_interop_test.go
+++ b/client/python_interop/python_interop_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	tuf "github.com/theupdateframework/go-tuf"
-	client "github.com/theupdateframework/go-tuf/client"
-	"github.com/theupdateframework/go-tuf/util"
+	tuf "github.com/DataDog/go-tuf"
+	client "github.com/DataDog/go-tuf/client"
+	"github.com/DataDog/go-tuf/util"
 	. "gopkg.in/check.v1"
 )
 
@@ -169,7 +169,7 @@ func (InteropSuite) TestPythonClientGoGenerated(c *C) {
 }
 
 // This is a regression test for issue
-// https://github.com/theupdateframework/go-tuf/issues/402
+// https://github.com/DataDog/go-tuf/issues/402
 func (InteropSuite) TestPythonClientGoGeneratedNullDelegations(c *C) {
 	// clone the Python client if necessary
 	cwd, err := os.Getwd()

--- a/client/testdata/go-tuf-transition-M3/generate.go
+++ b/client/testdata/go-tuf-transition-M3/generate.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/goccy/go-json"
 
-	tuf "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	tuf "github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 var expirationDate = time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/client/testdata/go-tuf-transition-M4/generate.go
+++ b/client/testdata/go-tuf-transition-M4/generate.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/goccy/go-json"
 
-	tuf "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	tuf "github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 var expirationDate = time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/client/testdata/go-tuf/generate.go
+++ b/client/testdata/go-tuf/generate.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/theupdateframework/go-tuf/client/testdata/go-tuf/generator"
+	"github.com/DataDog/go-tuf/client/testdata/go-tuf/generator"
 )
 
 func main() {

--- a/client/testdata/go-tuf/generator/generator.go
+++ b/client/testdata/go-tuf/generator/generator.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/goccy/go-json"
 
-	tuf "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	tuf "github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 var expirationDate = time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/client/testdata/tools/gen-keys.go
+++ b/client/testdata/tools/gen-keys.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 )
 
 var expirationDate = time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/cmd/tuf-client/README.md
+++ b/cmd/tuf-client/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-go get github.com/theupdateframework/go-tuf/cmd/tuf-client
+go get github.com/DataDog/go-tuf/cmd/tuf-client
 ```
 
 ## Usage

--- a/cmd/tuf-client/get.go
+++ b/cmd/tuf-client/get.go
@@ -4,9 +4,9 @@ import (
 	"io"
 	"os"
 
+	tuf "github.com/DataDog/go-tuf/client"
+	"github.com/DataDog/go-tuf/util"
 	"github.com/flynn/go-docopt"
-	tuf "github.com/theupdateframework/go-tuf/client"
-	"github.com/theupdateframework/go-tuf/util"
 )
 
 func init() {

--- a/cmd/tuf-client/init.go
+++ b/cmd/tuf-client/init.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"os"
 
+	tuf "github.com/DataDog/go-tuf/client"
 	"github.com/flynn/go-docopt"
-	tuf "github.com/theupdateframework/go-tuf/client"
 )
 
 func init() {

--- a/cmd/tuf-client/list.go
+++ b/cmd/tuf-client/list.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"text/tabwriter"
 
+	tuf "github.com/DataDog/go-tuf/client"
 	"github.com/dustin/go-humanize"
 	"github.com/flynn/go-docopt"
-	tuf "github.com/theupdateframework/go-tuf/client"
 )
 
 func init() {

--- a/cmd/tuf-client/main.go
+++ b/cmd/tuf-client/main.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"os"
 
+	tuf "github.com/DataDog/go-tuf/client"
+	tuf_leveldbstore "github.com/DataDog/go-tuf/client/leveldbstore"
 	docopt "github.com/flynn/go-docopt"
-	tuf "github.com/theupdateframework/go-tuf/client"
-	tuf_leveldbstore "github.com/theupdateframework/go-tuf/client/leveldbstore"
 )
 
 func main() {

--- a/cmd/tuf/add.go
+++ b/cmd/tuf/add.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/add_signatures.go
+++ b/cmd/tuf/add_signatures.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
 )
 
 func init() {

--- a/cmd/tuf/change_passphrase.go
+++ b/cmd/tuf/change_passphrase.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/clean.go
+++ b/cmd/tuf/clean.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/commit.go
+++ b/cmd/tuf/commit.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/gen_key.go
+++ b/cmd/tuf/gen_key.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
 )
 
 func init() {

--- a/cmd/tuf/get_threshold.go
+++ b/cmd/tuf/get_threshold.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {
 	register("get-threshold", cmdGetThreshold, `
 usage: tuf get-threshold <role>
 
-Gets the threshold for a role.  
+Gets the threshold for a role.
 `)
 }
 

--- a/cmd/tuf/init.go
+++ b/cmd/tuf/init.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
+	tuf "github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/util"
 	docopt "github.com/flynn/go-docopt"
-	tuf "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/util"
 	"golang.org/x/term"
 )
 

--- a/cmd/tuf/payload.go
+++ b/cmd/tuf/payload.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/regenerate.go
+++ b/cmd/tuf/regenerate.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/remove.go
+++ b/cmd/tuf/remove.go
@@ -3,8 +3,8 @@ package main
 import (
 	"errors"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/revoke_key.go
+++ b/cmd/tuf/revoke_key.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/root_keys.go
+++ b/cmd/tuf/root_keys.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/set_threshold.go
+++ b/cmd/tuf/set_threshold.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {
 	register("set-threshold", cmdSetThreshold, `
 usage: tuf set-threshold <role> <threshold>
 
-Set the threshold for a role.  
+Set the threshold for a role.
 `)
 }
 

--- a/cmd/tuf/sign.go
+++ b/cmd/tuf/sign.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/sign_payload.go
+++ b/cmd/tuf/sign_payload.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/goccy/go-json"
 
+	tuf "github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	tuf "github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/snapshot.go
+++ b/cmd/tuf/snapshot.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/status.go
+++ b/cmd/tuf/status.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/cmd/tuf/timestamp.go
+++ b/cmd/tuf/timestamp.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/DataDog/go-tuf"
 	"github.com/flynn/go-docopt"
-	"github.com/theupdateframework/go-tuf"
 )
 
 func init() {

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -13,7 +13,7 @@ Speedy communication makes contributors happy!
 - Please review all PRs within five business days (of course, it's okay if you're OOO).
 - Please use the review checklist below.
 - We should make sure there's an assigned reviewer for every PR which has passing tests.
-  
+
 Versioning:
 
 - go-tuf releases follow [SemVer](https://semver.org/) with the following modification:
@@ -30,7 +30,7 @@ Project management:
   - Feel free to ping open issues to check on them.
   - Use the "assignee" field to indicate when you are working on an issue.
   - Use GitHub issue labels to describe the issue (exact labels are still changing, so just look through and add those that seem like a good fit).
-- Before publishing a new minor release, there should be an associated [GitHub project](https://github.com/theupdateframework/go-tuf/projects?type=beta) to track issues.
+- Before publishing a new minor release, there should be an associated [GitHub project](https://github.com/DataDog/go-tuf/projects?type=beta) to track issues.
 - We will develop more process around project management after we get through the v0.4.0 release.
 
 ## Review checklist

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,7 +8,7 @@ You may report issues for the most recent version of go-tuf. We will not retroac
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify the go-tuf maintainers via [Github's private reporting feature](https://github.com/theupdateframework/go-tuf/security/advisories/new) (requires being signed in to GitHub). At the minimum, the report must contain the following:
+If you discover a potential security issue in this project we ask that you notify the go-tuf maintainers via [Github's private reporting feature](https://github.com/DataDog/go-tuf/security/advisories/new) (requires being signed in to GitHub). At the minimum, the report must contain the following:
 
 * A description of the issue.
 * A specific version or commit SHA of `go-tuf` where the issue reproduces.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/theupdateframework/go-tuf
+module github.com/DataDog/go-tuf
 
 go 1.18
 

--- a/internal/fsutil/perm_windows.go
+++ b/internal/fsutil/perm_windows.go
@@ -10,7 +10,7 @@ import (
 // UNIX-like permission bits. By setting the UNIX-like permission bits
 // on a Windows system only read/write by all users can be achieved.
 // See this issue for tracking and more details:
-// https://github.com/theupdateframework/go-tuf/issues/360
+// https://github.com/DataDog/go-tuf/issues/360
 // Currently this method will always return nil.
 func EnsureMaxPermissions(fi os.FileInfo, perm os.FileMode) error {
 	return nil

--- a/internal/signer/sort.go
+++ b/internal/signer/sort.go
@@ -3,7 +3,7 @@ package signer
 import (
 	"sort"
 
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 // ByIDs implements sort.Interface for []keys.Signer based on

--- a/internal/signer/sort_test.go
+++ b/internal/signer/sort_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/signer"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/signer"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 type mockSigner struct {

--- a/local_store.go
+++ b/local_store.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/encrypted"
-	"github.com/theupdateframework/go-tuf/internal/fsutil"
-	"github.com/theupdateframework/go-tuf/internal/sets"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
-	"github.com/theupdateframework/go-tuf/util"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/encrypted"
+	"github.com/DataDog/go-tuf/internal/fsutil"
+	"github.com/DataDog/go-tuf/internal/sets"
+	"github.com/DataDog/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/util"
 )
 
 type LocalStore interface {

--- a/local_store_test.go
+++ b/local_store_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/DataDog/go-tuf/pkg/keys"
 	"github.com/stretchr/testify/assert"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
 )
 
 func TestLocalStoreSigners(t *testing.T) {

--- a/pkg/deprecated/deprecated_repo_test.go
+++ b/pkg/deprecated/deprecated_repo_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/goccy/go-json"
 
+	repo "github.com/DataDog/go-tuf"
+	"github.com/DataDog/go-tuf/data"
+	_ "github.com/DataDog/go-tuf/pkg/deprecated/set_ecdsa"
+	"github.com/DataDog/go-tuf/pkg/keys"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
-	repo "github.com/theupdateframework/go-tuf"
-	"github.com/theupdateframework/go-tuf/data"
-	_ "github.com/theupdateframework/go-tuf/pkg/deprecated/set_ecdsa"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/deprecated/set_ecdsa/set_ecdsa.go
+++ b/pkg/deprecated/set_ecdsa/set_ecdsa.go
@@ -3,14 +3,14 @@ package set_ecdsa
 import (
 	"errors"
 
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 /*
 	Importing this package will allow support for both hex-encoded ECDSA
 	verifiers and PEM-encoded ECDSA verifiers.
-	Note that this package imports "github.com/theupdateframework/go-tuf/pkg/keys"
+	Note that this package imports "github.com/DataDog/go-tuf/pkg/keys"
 	and overrides the ECDSA verifier loaded at init time in that package.
 */
 

--- a/pkg/keys/deprecated_ecdsa.go
+++ b/pkg/keys/deprecated_ecdsa.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 )
 
 func NewDeprecatedEcdsaVerifier() Verifier {

--- a/pkg/keys/deprecated_ecdsa_test.go
+++ b/pkg/keys/deprecated_ecdsa_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/keys/ecdsa.go
+++ b/pkg/keys/ecdsa.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 )
 
 func init() {
@@ -46,7 +46,7 @@ func (p *EcdsaVerifier) Public() string {
 	r, err := x509.MarshalPKIXPublicKey(p.ecdsaKey)
 	if err != nil {
 		// TODO: Gracefully handle these errors.
-		// See https://github.com/theupdateframework/go-tuf/issues/363
+		// See https://github.com/DataDog/go-tuf/issues/363
 		panic(err)
 	}
 	return string(r)

--- a/pkg/keys/ecdsa_test.go
+++ b/pkg/keys/ecdsa_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
 	fuzz "github.com/google/gofuzz"
-	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/keys/ed25519.go
+++ b/pkg/keys/ed25519.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
 	"github.com/dgrijalva/lfu-go"
-	"github.com/theupdateframework/go-tuf/data"
 )
 
 var lfuCache *lfu.Cache

--- a/pkg/keys/ed25519_test.go
+++ b/pkg/keys/ed25519_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
 	fuzz "github.com/google/gofuzz"
-	"github.com/theupdateframework/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 )
 
 // MaxJSONKeySize defines the maximum length of a JSON payload.

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -3,7 +3,7 @@ package keys
 import (
 	"testing"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/keys/rsa.go
+++ b/pkg/keys/rsa.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 )
 
 func init() {
@@ -41,7 +41,7 @@ func (p *rsaVerifier) Public() string {
 	r, err := x509.MarshalPKIXPublicKey(p.rsaKey)
 	if err != nil {
 		// TODO: Gracefully handle these errors.
-		// See https://github.com/theupdateframework/go-tuf/issues/363
+		// See https://github.com/DataDog/go-tuf/issues/363
 		panic(err)
 	}
 	return string(r)

--- a/pkg/keys/rsa_test.go
+++ b/pkg/keys/rsa_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/targets/delegation.go
+++ b/pkg/targets/delegation.go
@@ -3,9 +3,9 @@ package targets
 import (
 	"errors"
 
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/sets"
-	"github.com/theupdateframework/go-tuf/verify"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/sets"
+	"github.com/DataDog/go-tuf/verify"
 )
 
 type Delegation struct {

--- a/pkg/targets/delegation_test.go
+++ b/pkg/targets/delegation_test.go
@@ -3,9 +3,9 @@ package targets
 import (
 	"testing"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/verify"
 	"github.com/stretchr/testify/assert"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/verify"
 )
 
 var (

--- a/repo.go
+++ b/repo.go
@@ -14,16 +14,16 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/roles"
+	"github.com/DataDog/go-tuf/internal/sets"
+	"github.com/DataDog/go-tuf/internal/signer"
+	"github.com/DataDog/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/pkg/targets"
+	"github.com/DataDog/go-tuf/sign"
+	"github.com/DataDog/go-tuf/util"
+	"github.com/DataDog/go-tuf/verify"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/roles"
-	"github.com/theupdateframework/go-tuf/internal/sets"
-	"github.com/theupdateframework/go-tuf/internal/signer"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
-	"github.com/theupdateframework/go-tuf/pkg/targets"
-	"github.com/theupdateframework/go-tuf/sign"
-	"github.com/theupdateframework/go-tuf/util"
-	"github.com/theupdateframework/go-tuf/verify"
 )
 
 const (
@@ -1113,7 +1113,7 @@ func (r *Repo) AddTargetsToPreferredRole(paths []string, custom json.RawMessage,
 
 func (r *Repo) AddTargetsWithDigest(digest string, digestAlg string, length int64, path string, custom json.RawMessage) error {
 	// TODO: Rename this to AddTargetWithDigest
-	// https://github.com/theupdateframework/go-tuf/issues/242
+	// https://github.com/DataDog/go-tuf/issues/242
 
 	expires := data.DefaultExpires("targets")
 	path = util.NormalizeTarget(path)
@@ -1231,7 +1231,7 @@ func (r *Repo) AddTargetsWithExpiresToPreferredRole(paths []string, custom json.
 
 	if len(updatedTargetsMeta) == 0 {
 		// This is potentially unexpected behavior kept for backwards compatibility.
-		// See https://github.com/theupdateframework/go-tuf/issues/243
+		// See https://github.com/DataDog/go-tuf/issues/243
 		t, err := r.topLevelTargets()
 		if err != nil {
 			return err
@@ -1504,7 +1504,7 @@ func (r *Repo) fileHashes() (map[string]data.Hashes, error) {
 
 			if roleName != "root" {
 				// Scalability issue: Commit/fileHashes loads all targets metadata into memory
-				// https://github.com/theupdateframework/go-tuf/issues/245
+				// https://github.com/DataDog/go-tuf/issues/245
 				t, err := r.targets(roleName)
 				if err != nil {
 					return nil, err

--- a/repo_test.go
+++ b/repo_test.go
@@ -20,14 +20,14 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/encrypted"
+	"github.com/DataDog/go-tuf/internal/sets"
+	"github.com/DataDog/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/pkg/targets"
+	"github.com/DataDog/go-tuf/util"
+	"github.com/DataDog/go-tuf/verify"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/encrypted"
-	"github.com/theupdateframework/go-tuf/internal/sets"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
-	"github.com/theupdateframework/go-tuf/pkg/targets"
-	"github.com/theupdateframework/go-tuf/util"
-	"github.com/theupdateframework/go-tuf/verify"
 	"golang.org/x/crypto/ed25519"
 	. "gopkg.in/check.v1"
 )

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
 )
 
 const maxSignatures = 1024

--- a/util/util.go
+++ b/util/util.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 )
 
 type ErrWrongLength struct {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -8,7 +8,7 @@ import (
 	"hash"
 	"testing"
 
-	"github.com/theupdateframework/go-tuf/data"
+	"github.com/DataDog/go-tuf/data"
 	. "gopkg.in/check.v1"
 )
 

--- a/verify/db.go
+++ b/verify/db.go
@@ -1,9 +1,9 @@
 package verify
 
 import (
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/roles"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/roles"
+	"github.com/DataDog/go-tuf/pkg/keys"
 )
 
 type Role struct {

--- a/verify/db_test.go
+++ b/verify/db_test.go
@@ -3,9 +3,9 @@ package verify
 import (
 	"testing"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
 	"github.com/stretchr/testify/assert"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
 )
 
 func TestDelegationsDB(t *testing.T) {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/internal/roles"
+	"github.com/DataDog/go-tuf/pkg/keys"
 	"github.com/dgrijalva/lfu-go"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/internal/roles"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
 )
 
 var lfuCache *lfu.Cache

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/goccy/go-json"
 
-	"github.com/theupdateframework/go-tuf/data"
-	"github.com/theupdateframework/go-tuf/pkg/keys"
-	"github.com/theupdateframework/go-tuf/sign"
+	"github.com/DataDog/go-tuf/data"
+	"github.com/DataDog/go-tuf/pkg/keys"
+	"github.com/DataDog/go-tuf/sign"
 	"golang.org/x/crypto/ed25519"
 
 	. "gopkg.in/check.v1"


### PR DESCRIPTION
Replaces all imports to local ones so this repository can be tagged on master & imported in the agent