### PR TITLE
perf: (rc) batch Download and Target

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"io"
 
 	"github.com/DataDog/go-tuf/data"
@@ -446,55 +445,6 @@ func (c *Client) getLocalMeta() error {
 	return nil
 }
 
-// getDelegationPathFromRaw verifies a delegated targets against
-// a given snapshot and returns an error if it's invalid
-//
-// Delegation must have targets to get a path, else an empty list
-// will be returned: this is because the delegation iterator is leveraged.
-//
-// Concrete example:
-// targets
-// └── a.json
-//   └── b.json
-//      └── c.json
-//        └── target_file.txt
-//
-// If you try to use that function on "a.json" or "b.json", it'll return an empty list
-// with no error, as neither of them declare a target file
-// On the other hand, if you use that function on "c.json", it'll return & verify
-// [c.json, b.json, a.json]. Running that function on every delegated targets
-// guarantees that if a delegated targets is in the path of a target file, then it will
-// appear at least once in the result
-func (c *Client) getDelegationPathFromRaw(snapshot *data.Snapshot, delegatedTargetsJSON json.RawMessage) ([]string, error) {
-	// unmarshal the delegated targets first without verifying as
-	// we need at least one targets file name to leverage the
-	// getTargetFileMetaDelegationPath method
-	s := &data.Signed{}
-	if err := json.Unmarshal(delegatedTargetsJSON, s); err != nil {
-		return nil, err
-	}
-	targets := &data.Targets{}
-	if err := json.Unmarshal(s.Signed, targets); err != nil {
-		return nil, err
-	}
-	for targetPath := range targets.Targets {
-		// Gets target file from remote store
-		_, resp, err := c.getTargetFileMetaDelegationPath(targetPath, snapshot)
-		// We only need to test one targets file:
-		// - If it is valid, it means the delegated targets has been validated
-		// - If it is not, the delegated targets isn't valid
-		if errors.As(err, &ErrMissingRemoteMetadata{}) {
-			// As this function is used to fill the local store cache, the targets
-			// will be downloaded from the remote store as the local store cache is
-			// empty, meaning that the delegated targets may not exist anymore. In
-			// that case, ignore it.
-			return nil, nil
-		}
-		return resp, err
-	}
-	return nil, nil
-}
-
 // loadAndVerifyLocalRootMeta decodes and verifies root metadata from
 // local storage and loads the top-level keys. This method first clears
 // the DB for top-level keys and then loads the new keys.
@@ -875,10 +825,17 @@ type Destination interface {
 //   - Size of the download does not match if the reported size is known and
 //     incorrect
 func (c *Client) Download(name string, dest Destination) (err error) {
+	return c.DownloadBatch(map[string]Destination{name: dest})
+}
+
+// DownloadBatch is a batched version of Download.
+func (c *Client) DownloadBatch(targetFiles map[string]Destination) (err error) {
 	// delete dest if there is an error
 	defer func() {
 		if err != nil {
-			dest.Delete()
+			for _, dest := range targetFiles {
+				dest.Delete()
+			}
 		}
 	}()
 
@@ -889,45 +846,48 @@ func (c *Client) Download(name string, dest Destination) (err error) {
 		}
 	}
 
-	normalizedName := util.NormalizeTarget(name)
-	localMeta, ok := c.targets[normalizedName]
-	if !ok {
-		// search in delegations
-		localMeta, err = c.getTargetFileMeta(normalizedName)
-		if err != nil {
-			return err
-		}
+	var names []string
+	for name := range targetFiles {
+		names = append(names, name)
 	}
-
-	// get the data from remote storage
-	r, size, err := c.downloadTarget(normalizedName, c.remote.GetTarget, localMeta.Hashes)
+	targets, err := c.getTargetFileMetas(names)
 	if err != nil {
 		return err
 	}
-	defer r.Close()
 
-	// return ErrWrongSize if the reported size is known and incorrect
-	if size >= 0 && size != localMeta.Length {
-		return ErrWrongSize{name, size, localMeta.Length}
-	}
+	for name, dest := range targetFiles {
+		localMeta := targets[name]
 
-	// wrap the data in a LimitReader so we download at most localMeta.Length bytes
-	stream := io.LimitReader(r, localMeta.Length)
-
-	// read the data, simultaneously writing it to dest and generating metadata
-	actual, err := util.GenerateTargetFileMeta(io.TeeReader(stream, dest), localMeta.HashAlgorithms()...)
-	if err != nil {
-		return ErrDownloadFailed{name, err}
-	}
-
-	// check the data has the correct length and hashes
-	if err := util.TargetFileMetaEqual(actual, localMeta); err != nil {
-		if e, ok := err.(util.ErrWrongLength); ok {
-			return ErrWrongSize{name, e.Actual, e.Expected}
+		// get the data from remote storage
+		normalizedName := util.NormalizeTarget(name)
+		r, size, err := c.downloadTarget(normalizedName, c.remote.GetTarget, localMeta.Hashes)
+		if err != nil {
+			return err
 		}
-		return ErrDownloadFailed{name, err}
-	}
+		defer r.Close()
 
+		// return ErrWrongSize if the reported size is known and incorrect
+		if size >= 0 && size != localMeta.Length {
+			return ErrWrongSize{name, size, localMeta.Length}
+		}
+
+		// wrap the data in a LimitReader so we download at most localMeta.Length bytes
+		stream := io.LimitReader(r, localMeta.Length)
+
+		// read the data, simultaneously writing it to dest and generating metadata
+		actual, err := util.GenerateTargetFileMeta(io.TeeReader(stream, dest), localMeta.HashAlgorithms()...)
+		if err != nil {
+			return ErrDownloadFailed{name, err}
+		}
+
+		// check the data has the correct length and hashes
+		if err := util.TargetFileMetaEqual(actual, localMeta); err != nil {
+			if e, ok := err.(util.ErrWrongLength); ok {
+				return ErrWrongSize{name, e.Actual, e.Expected}
+			}
+			return ErrDownloadFailed{name, err}
+		}
+	}
 	return nil
 }
 
@@ -958,16 +918,23 @@ func (c *Client) VerifyDigest(digest string, digestAlg string, length int64, pat
 // exists, searching from top-level level targets then through
 // all delegations. If it does not, ErrNotFound will be returned.
 func (c *Client) Target(name string) (data.TargetFileMeta, error) {
-	target, err := c.getTargetFileMeta(util.NormalizeTarget(name))
+	targets, err := c.TargetBatch([]string{name})
+	if err != nil {
+		return data.TargetFileMeta{}, err
+	}
+	return targets[name], nil
+}
+
+// TargetBatch is a batched version of Target.
+func (c *Client) TargetBatch(names []string) (data.TargetFiles, error) {
+	targets, err := c.getTargetFileMetas(names)
 	if err == nil {
-		return target, nil
+		return targets, nil
 	}
-
 	if _, ok := err.(ErrUnknownTarget); ok {
-		return data.TargetFileMeta{}, ErrNotFound{name}
+		return nil, ErrNotFound{err.(ErrUnknownTarget).Name}
 	}
-
-	return data.TargetFileMeta{}, err
+	return nil, err
 }
 
 // Targets returns the complete list of available top-level targets.

--- a/client/delegations.go
+++ b/client/delegations.go
@@ -3,28 +3,69 @@ package client
 import (
 	"github.com/DataDog/go-tuf/data"
 	"github.com/DataDog/go-tuf/pkg/targets"
+	"github.com/DataDog/go-tuf/util"
 	"github.com/DataDog/go-tuf/verify"
 )
+
+type delegatedTargetsCache struct {
+	meta map[string]*data.Targets
+}
+
+func newDelegatedTargetsCache() *delegatedTargetsCache {
+	return &delegatedTargetsCache{
+		meta: make(map[string]*data.Targets),
+	}
+}
+
+func (c *delegatedTargetsCache) loadDelegatedTargets(client *Client, snapshot *data.Snapshot, role string, db *verify.DB) (*data.Targets, error) {
+	if t, ok := c.meta[role]; ok {
+		return t, nil
+	}
+
+	targets, err := client.loadDelegatedTargets(snapshot, role, db)
+	if err != nil {
+		return nil, err
+	}
+
+	c.meta[role] = targets
+	return targets, nil
+}
 
 // getTargetFileMeta searches for a verified TargetFileMeta matching a target
 // Requires a local snapshot to be loaded and is locked to the snapshot versions.
 func (c *Client) getTargetFileMeta(target string) (data.TargetFileMeta, error) {
+	metas, err := c.getTargetFileMetas([]string{target})
+	if err != nil {
+		return data.TargetFileMeta{}, err
+	}
+	return metas[target], nil
+}
+
+func (c *Client) getTargetFileMetas(targets []string) (data.TargetFiles, error) {
 	snapshot, err := c.loadLocalSnapshot()
 	if err != nil {
-		return data.TargetFileMeta{}, err
+		return nil, err
 	}
-
-	targetFileMeta, _, err := c.getTargetFileMetaDelegationPath(target, snapshot)
-	if err != nil {
-		return data.TargetFileMeta{}, err
+	cache := newDelegatedTargetsCache()
+	targetFileMetas := make(data.TargetFiles, len(targets))
+	for _, target := range targets {
+		normalizedTarget := util.NormalizeTarget(target)
+		targetFileMeta, _, err := c.getTargetFileMetaDelegationPath(normalizedTarget, snapshot, cache)
+		if _, ok := err.(ErrUnknownTarget); ok {
+			return nil, ErrUnknownTarget{target, snapshot.Version}
+		}
+		if err != nil {
+			return nil, err
+		}
+		targetFileMetas[target] = targetFileMeta
 	}
-	return targetFileMeta, nil
+	return targetFileMetas, nil
 }
 
 // getTargetFileMetaDelegationPath searches for a verified TargetFileMeta matching a target
 // Requires snapshot to be passed and is locked to that specific snapshot versions.
 // Searches through delegated targets following TUF spec 1.0.19 section 5.6.
-func (c *Client) getTargetFileMetaDelegationPath(target string, snapshot *data.Snapshot) (data.TargetFileMeta, []string, error) {
+func (c *Client) getTargetFileMetaDelegationPath(target string, snapshot *data.Snapshot, cache *delegatedTargetsCache) (data.TargetFileMeta, []string, error) {
 	// delegationsIterator covers 5.6.7
 	// - pre-order depth-first search starting with the top targets
 	// - filter delegations with paths or path_hash_prefixes matching searched target
@@ -45,7 +86,7 @@ func (c *Client) getTargetFileMetaDelegationPath(target string, snapshot *data.S
 		}
 
 		// covers 5.6.{1,2,3,4,5,6}
-		targets, err := c.loadDelegatedTargets(snapshot, d.Delegatee.Name, d.DB)
+		targets, err := cache.loadDelegatedTargets(c, snapshot, d.Delegatee.Name, d.DB)
 		if err != nil {
 			return data.TargetFileMeta{}, nil, err
 		}


### PR DESCRIPTION
This PR adds batched versions of the `client.Target` and `client.Download` functions. This allows far more efficient retrieval of a large number of files at one time.